### PR TITLE
Small addition to allow it to variably change its sample count.

### DIFF
--- a/src/given.js
+++ b/src/given.js
@@ -16,7 +16,7 @@ module.exports = {
   rollingSound: 'static/rolling.wav', // The sound made when the ball rolls.
   clinkSound: 'static/clink.wav',     // The sound made when the ball hits something.
   dingSound: 'static/ding.wav',       // The sound made at the end of each level.
-  initialResolution: 4                // Initial resolution scaling.
+  initialResolution: 4,                // Initial resolution scaling.
   targetFPS: 60,					  // The FPS to try and get. ADDITION FROM Bram S.
   maxSamples: 256,					  // The maximum samples per pixel per frame. ADDITION FROM Bram S.
 };

--- a/src/given.js
+++ b/src/given.js
@@ -17,4 +17,6 @@ module.exports = {
   clinkSound: 'static/clink.wav',     // The sound made when the ball hits something.
   dingSound: 'static/ding.wav',       // The sound made at the end of each level.
   initialResolution: 4                // Initial resolution scaling.
+  targetFPS: 60,					  // The FPS to try and get. ADDITION FROM Bram S.
+  maxSamples: 256,					  // The maximum samples per pixel per frame. ADDITION FROM Bram S.
 };

--- a/src/view.js
+++ b/src/view.js
@@ -247,11 +247,23 @@ module.exports = async function Renderer(canvas) {
     // Figure out the current time so that we can set the sun position.
     let time = performance.now() * 0.00001 + 0.1;
 
-    // We'll take this many samples before rendering to the screen.
-    let sampleCount = 4;
+    // OLD: We'll take this many samples before rendering to the screen.
+	// Start at 0 samples. ADDITION FROM Bram S.
+    let sampleCount = 0;
 
+    // The time at which we start this frame. ADDITION FROM Bram S.
+	let startTime = performance.now();
+	// The maximum samples for a single frame. ADDITION FROM Bram S.
+	let maxSamples = given.maxSamples;
+	
     // Take sampleCount samples.
-    for (let i = 0; i < sampleCount; i++) {
+    // OLD:  for (let i = 0; i < sampleCount; i++) {
+	// Keep going until it takes longer than (60.0 / targetFPS) milliseconds (in this case 1 ms). ADDITION FROM Bram S.
+	// We always want at least one sample, so therefor the "sampleCount == 0" and we also have a maximum amount of samples.
+	while((performance.now() - startTime < (60.0 / given.targetFPS) || sampleCount == 0) && sampleCount < maxSamples){
+	  // Add to the sample count for proper averaging. ADDITION FROM Bram S.
+	  sampleCount += 1;
+	  
       regl.clear({
         depth: 1,
         framebuffer: pingPong[pingPongIndex]


### PR DESCRIPTION
When doing the sampling part in the rendering code, it used to use a simple for loop with a fixed amount of loops (decided by sampleCount).

In my version, I changed it to a while loop and I recorded the amount of time it takes to do the sampling. When the sampling takes longer than x amount of milliseconds, it stops sampling. Currently at a target FPS of 60, it may only take 1ms to do the sampling. However, that is still enough to get anywhere between 40 and 170 samples per pixel on my computer (1080ti and i9-7940x). To prevent black frames, it must do at least one sample per pixel. In order to prevent it from taking up too much power, I added a limit of 256 samples per pixel (although my computer does not reach it).

With 4 samples per pixel:
![image](https://user-images.githubusercontent.com/8073547/49014987-18dd5100-f182-11e8-9919-c23611de693b.png)
With variable samples per pixel:
![image](https://user-images.githubusercontent.com/8073547/49015018-301c3e80-f182-11e8-86cb-f85a1a6860ec.png)
